### PR TITLE
fix: Opus tagging, AcoustID invalid key guard

### DIFF
--- a/fingerprint.py
+++ b/fingerprint.py
@@ -21,6 +21,7 @@ RATE_LIMIT_INTERVAL = 0.34  # ~3 requests per second
 
 _last_request_time = 0.0
 _fpcalc_warned = False
+_api_key_invalid = False
 _throttle_lock = threading.Lock()
 
 
@@ -67,10 +68,9 @@ def _throttle():
 
 
 def _lookup_acoustid(api_key, duration, fingerprint):
-    """Look up a fingerprint against the AcoustID API.
-
-    Returns list of result dicts, or None on error.
-    """
+    global _api_key_invalid
+    if _api_key_invalid:
+        return None
     params = {
         "client": api_key,
         "duration": int(duration),
@@ -88,10 +88,17 @@ def _lookup_acoustid(api_key, duration, fingerprint):
             r.raise_for_status()
         data = r.json()
         if data.get("status") != "ok":
-            logger.warning(
-                "AcoustID API error: %s",
-                data.get("error", {}).get("message", "unknown"),
-            )
+            error = data.get("error", {})
+            if error.get("code") == 4:
+                _api_key_invalid = True
+                logger.error(
+                    "AcoustID API key is invalid. "
+                    "Register a key at https://acoustid.org/new-application "
+                    "and set it in Settings > AcoustID API Key. "
+                    "Fingerprinting disabled for this session."
+                )
+            else:
+                logger.warning("AcoustID API error: %s", error.get("message", "unknown"))
             return None
         return data.get("results", [])
     except requests.exceptions.RequestException as e:

--- a/metadata.py
+++ b/metadata.py
@@ -4,11 +4,13 @@ Handles MP3 tagging with MusicBrainz IDs, XML metadata generation for
 Lidarr import, and iTunes API lookups for track lists and album artwork.
 """
 
+import base64
 import logging
 import os
 from xml.sax.saxutils import escape as xml_escape
 
 import requests
+from mutagen.flac import Picture
 from mutagen.id3 import (
     APIC,
     ID3,
@@ -22,6 +24,7 @@ from mutagen.id3 import (
     UFID,
 )
 from mutagen.mp3 import MP3
+from mutagen.oggopus import OggOpus
 
 from lidarr import get_monitored_release
 from utils import sanitize_filename
@@ -105,6 +108,62 @@ def tag_mp3(file_path, track_info, album_info, cover_data):
     except Exception as e:
         logger.warning(f"Failed to tag MP3 {file_path}: {e}")
         return False
+
+
+def tag_opus(file_path, track_info, album_info, cover_data):
+    try:
+        audio = OggOpus(file_path)
+
+        audio["title"] = [track_info["title"]]
+        audio["artist"] = [album_info["artist"]["artistName"]]
+        audio["albumartist"] = [album_info["artist"]["artistName"]]
+        audio["album"] = [album_info["title"]]
+        audio["date"] = [str(album_info.get("releaseDate", "")[:4])]
+
+        try:
+            t_num = int(track_info["trackNumber"])
+            total = album_info.get("trackCount", 0)
+            audio["tracknumber"] = [f"{t_num}/{total}"]
+        except (ValueError, KeyError):
+            pass
+
+        release = get_monitored_release(album_info)
+        if release:
+            if track_info.get("foreignRecordingId"):
+                audio["musicbrainz_trackid"] = [track_info["foreignRecordingId"]]
+            if release.get("foreignReleaseId"):
+                audio["musicbrainz_albumid"] = [release["foreignReleaseId"]]
+            if album_info["artist"].get("foreignArtistId"):
+                audio["musicbrainz_artistid"] = [album_info["artist"]["foreignArtistId"]]
+            if album_info.get("foreignAlbumId"):
+                audio["musicbrainz_releasegroupid"] = [album_info["foreignAlbumId"]]
+            if release.get("country"):
+                audio["releasecountry"] = [release["country"]]
+
+        if track_info.get("foreignRecordingId"):
+            audio["musicbrainz_trackid"] = [track_info["foreignRecordingId"]]
+
+        if cover_data:
+            pic = Picture()
+            pic.type = 3
+            pic.mime = "image/jpeg"
+            pic.data = cover_data
+            audio["metadata_block_picture"] = [
+                base64.b64encode(pic.write()).decode("ascii")
+            ]
+
+        audio.save()
+        return True
+    except Exception as e:
+        logger.warning(f"Failed to tag Opus {file_path}: {e}")
+        return False
+
+
+def tag_audio_file(file_path, track_info, album_info, cover_data):
+    ext = os.path.splitext(file_path)[1].lower()
+    if ext == ".opus":
+        return tag_opus(file_path, track_info, album_info, cover_data)
+    return tag_mp3(file_path, track_info, album_info, cover_data)
 
 
 def _add_musicbrainz_tags(audio, track_info, album_info, release):

--- a/processing.py
+++ b/processing.py
@@ -24,9 +24,9 @@ from fingerprint import fingerprint_track, verify_fingerprint
 from lidarr import get_valid_release_id, lidarr_request
 from metadata import (
     create_xml_metadata,
+    tag_audio_file,
     get_itunes_artwork,
     get_itunes_tracks,
-    tag_mp3,
 )
 from notifications import (
     build_musicbrainz_link,
@@ -935,7 +935,7 @@ def _download_tracks(
             track_state["youtube_title"] = dl_result.get(
                 "youtube_title", "",
             )
-            tag_mp3(actual_file, track, album, cover_data)
+            tag_audio_file(actual_file, track, album, cover_data)
 
             cfg = load_config()
             should_verify = (
@@ -1166,7 +1166,7 @@ def _download_tracks(
                     track_state["youtube_title"] = fb_result.get(
                         "youtube_title", "",
                     )
-                    tag_mp3(fb_file, track, album, cover_data)
+                    tag_audio_file(fb_file, track, album, cover_data)
                     file_size, td_id = _accept_track_file(
                         fb_file, track_num, sanitized_track,
                         fb_result, {},


### PR DESCRIPTION
tag_opus + tag_audio_file dispatcher in metadata.py for Opus files (VorbisComment via OggOpus instead of ID3/MP3).
processing.py now calls tag_audio_file which routes by extension.

fingerprint.py: on AcoustID error code 4 (invalid key) set session flag _api_key_invalid so subsequent tracks skip the lookup instead of spamming the log with repeated 400 errors. Log one clear message with the registration URL.
