### PR TITLE
fix: add missing audio extensions to _cleanup_temp_files

### DIFF
--- a/app.py
+++ b/app.py
@@ -1226,7 +1226,7 @@ def _build_ydl_opts(config, temp_file):
 
 
 def _cleanup_temp_files(temp_file):
-    for ext in [".mp3", ".webm", ".m4a", ".part"]:
+    for ext in [".mp3", ".opus", ".flac", ".aac", ".ogg", ".webm", ".m4a", ".part"]:
         tmp = temp_file + ext
         if os.path.exists(tmp):
             try:

--- a/processing.py
+++ b/processing.py
@@ -491,7 +491,7 @@ def _filter_tracks(tracks, force, album_path):
 
 def _cleanup_temp_files(temp_file):
     """Remove temp download files for all common extensions."""
-    for ext in [".mp3", ".webm", ".m4a", ".part", ""]:
+    for ext in [".mp3", ".opus", ".flac", ".aac", ".ogg", ".webm", ".m4a", ".part", ""]:
         tmp = temp_file + ext
         if os.path.exists(tmp):
             try:


### PR DESCRIPTION
The cleanup function only tried .mp3, .webm, .m4a extensions so temp files in .opus (and other formats) were never deleted after a failed AcoustID verification or download error. Added .opus, .flac, .aac, .ogg to both the processing.py and app.py copies.
