### PR TITLE
fix(docker): switch base to python:3-slim for working deno runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:alpine
+FROM python:3-slim
 
-RUN apk update && apk upgrade --no-cache && \
-    apk add --no-cache ffmpeg gosu ca-certificates chromaprint curl && \
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+        ffmpeg gosu ca-certificates libchromaprint-tools curl unzip && \
     curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh && \
-    apk del curl
+    apt-get purge -y curl unzip && apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

Commit cca0013 replaced `apk add deno` with `deno.land/install.sh` to pick up CVE patches and satisfy yt-dlp-ejs's minimum deno version requirements. Both motivations are valid - Alpine's stable `deno 2.3.1` is vulnerable to several CVEs and is too old for yt-dlp-ejs 0.8.0, which silently marks the runtime as `(unavailable)` and falls back to no JS runtime.

However, `deno.land/install.sh` only ships glibc-linked binaries (`x86_64-unknown-linux-gnu`). Deno has never published official musl builds ([denoland/deno#3711](https://github.com/denoland/deno/issues/3711), open since 2020). On `python:alpine` (musl), the binary installs but cannot execute - the glibc dynamic linker and symbols are absent. All YouTube downloads silently fail with `deno (unavailable)` and yt-dlp falls back to no JS runtime.

## Alternatives considered

**Multi-stage COPY from `denoland/deno:alpine`:** not viable. Despite the `alpine` tag, the upstream Deno image layers glibc on top of Alpine (gcompat-style), so the binary inside is glibc-linked and fails identically when copied into a clean Alpine base.

**Alpine edge/community repo (currently ships deno 2.7.4-r1, musl-native):** works technically, but relies on the edge branch, which is explicitly not recommended for production by the Alpine project. Introduces ongoing ABI-mismatch risk when mixing edge packages with a stable base.

**Revert to stable `apk add deno` (2.3.1):** restores function but forfeits both the CVE fixes and the yt-dlp-ejs version floor.

## Fix

Switch the base image from `python:alpine` to `python:3-slim`. The existing `deno.land/install.sh` call then works exactly as cca0013 intended - the install script's glibc binary runs natively on Debian's glibc.

Trade-offs:
- Final image grows ~150 MB (roughly 350 MB → 500 MB extracted).
- Package name: Alpine's `chromaprint` → Debian's `libchromaprint-tools` (same binary, different distro packaging).
- `apk add` → `apt-get install`; `unzip` added as a build-time dep for the deno install script (purged in the same layer).

## Verification

Built and tested locally on the `fix/deno-alpine-musl-compat` branch. `deno --version` reports `2.7.12 (x86_64-unknown-linux-gnu)`, yt-dlp detects the runtime as `JS runtimes: deno-2.7.12`, and downloads that previously failed with signature-solving errors now return full audio format listings and complete successfully.