### PR TITLE
Fix pylint bugs related to unused variables

### DIFF
--- a/app.py
+++ b/app.py
@@ -649,19 +649,19 @@ def _enrich_track_logs(items):
         album_id = item.get("album_id")
         if album_id is None:
             banned_lookup = {}
-        elif album_id not in banned_cache:
-            try:
-                banned = models.get_banned_urls_for_album(album_id)
-                banned_cache[album_id] = {
-                    b["youtube_url"]: b["id"] for b in banned
-                }
-            except Exception:
-                logger.warning(
-                    "Failed to fetch banned URLs for album %s",
-                    album_id, exc_info=True,
-                )
-                banned_cache[album_id] = {}
-        if album_id is not None:
+        else:
+            if album_id not in banned_cache:
+                try:
+                    banned = models.get_banned_urls_for_album(album_id)
+                    banned_cache[album_id] = {
+                        b["youtube_url"]: b["id"] for b in banned
+                    }
+                except Exception:
+                    logger.warning(
+                        "Failed to fetch banned URLs for album %s",
+                        album_id, exc_info=True,
+                    )
+                    banned_cache[album_id] = {}
             banned_lookup = banned_cache[album_id]
         for c in candidates:
             url = c.get("youtube_url", "")

--- a/lidarr.py
+++ b/lidarr.py
@@ -37,6 +37,8 @@ def lidarr_request(endpoint, method="GET", data=None, params=None):
             r = requests.post(
                 url, headers=headers, json=data, timeout=30
             )
+        else:
+            raise ValueError(f"Unsupported method: {method}")
         r.raise_for_status()
         return r.json()
     except requests.exceptions.ConnectionError as e:


### PR DESCRIPTION
Fixed some pylint bugs related to potentially unassigned variables.

- Fixed E0606 in app.py where `banned_lookup` could be used before assignment by changing the `elif` branch into an `else` branch with nested `if`.
- Fixed E0606 in lidarr.py where `r` could be used before assignment by throwing `ValueError` for unsupported HTTP methods.

---
*PR created automatically by Jules for task [4933777215143074842](https://jules.google.com/task/4933777215143074842) started by @Angrido*