### PR TITLE
Support configurable audio formats and improve failed track retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🎵 Lidarr YouTube Downloader
 
-![Version](https://img.shields.io/badge/version-1.6.6-blue.svg?style=for-the-badge)
+![Version](https://img.shields.io/badge/version-1.6.7-blue.svg?style=for-the-badge)
 ![Python Slim](https://img.shields.io/badge/python-3--slim-yellow.svg?style=for-the-badge&logo=python&logoColor=white)
 ![Docker](https://img.shields.io/badge/docker-ready-blue.svg?style=for-the-badge&logo=docker&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-green.svg?style=for-the-badge)

--- a/app.py
+++ b/app.py
@@ -574,18 +574,24 @@ def api_delete_track(track_id):
     sanitized_track = sanitize_filename(track_data["track_title"])
     track_num = track_data["track_number"] or 0
     album_path = track_data["album_path"]
-    mp3_name = f"{track_num:02d} - {sanitized_track}.mp3"
     xml_name = f"{track_num:02d} - {sanitized_track}.xml"
-    mp3_path = os.path.join(album_path, mp3_name)
     xml_path = os.path.join(album_path, xml_name)
 
-    try:
-        os.remove(mp3_path)
-        file_deleted = True
-    except FileNotFoundError:
-        logger.warning("Track file not found for deletion: %s", mp3_path)
-    except OSError:
-        logger.error("Failed to delete track file: %s", mp3_path, exc_info=True)
+    cfg_ext = load_config().get("audio_format", "mp3")
+    audio_exts = [cfg_ext] + [e for e in ["mp3", "opus", "flac", "aac", "ogg", "m4a"] if e != cfg_ext]
+    for ext in audio_exts:
+        candidate = os.path.join(album_path, f"{track_num:02d} - {sanitized_track}.{ext}")
+        try:
+            os.remove(candidate)
+            file_deleted = True
+            break
+        except FileNotFoundError:
+            continue
+        except OSError:
+            logger.error("Failed to delete track file: %s", candidate, exc_info=True)
+            break
+    if not file_deleted:
+        logger.warning("Track file not found for deletion: %s/%02d - %s.*", album_path, track_num, sanitized_track)
     try:
         os.remove(xml_path)
     except OSError:
@@ -726,7 +732,9 @@ def api_dismiss_log(log_id):
 
 @app.route("/api/download/failed")
 def api_download_failed():
-    album_id = models.get_latest_download_album_id()
+    album_id = request.args.get("album_id", type=int)
+    if album_id is None:
+        album_id = models.get_latest_download_album_id()
     if album_id is None:
         return jsonify(
             {
@@ -1023,22 +1031,43 @@ def api_download_manual():
         ), 500
 
     failed_ctx = models.get_failed_tracks_for_retry(album_id_ctx)
-    dl_album_path = failed_ctx.get("album_path", "")
-    lidarr_album_path_val = failed_ctx.get("lidarr_album_path", "")
-    target_path = (
-        lidarr_album_path_val
-        if lidarr_album_path_val and os.path.isdir(lidarr_album_path_val)
-        else dl_album_path
-    )
+    config = load_config()
+    lidarr_path = config.get("lidarr_path", "")
+
+    # Recompute the correct album folder from current album metadata.
+    # The lidarr_album_path stored in the DB is often "" because it is
+    # recorded before _copy_to_lidarr() runs, so we can't rely on it.
+    artist_name_meta = album_data.get("artist", {}).get("artistName", "")
+    album_title_meta = album_data.get("title", "")
+    release_year_meta = str(album_data.get("releaseDate", ""))[:4]
+    san_artist = sanitize_filename(artist_name_meta)
+    san_album = sanitize_filename(album_title_meta)
+    if release_year_meta:
+        album_folder_meta = f"{san_album} ({release_year_meta})"
+    else:
+        album_folder_meta = san_album
+
+    if lidarr_path:
+        target_path = os.path.join(lidarr_path, san_artist, album_folder_meta)
+    elif DOWNLOAD_DIR:
+        target_path = os.path.join(DOWNLOAD_DIR, san_artist, album_folder_meta)
+    else:
+        # Last resort: fall back to whatever the DB has
+        lidarr_album_path_val = failed_ctx.get("lidarr_album_path", "")
+        dl_album_path = failed_ctx.get("album_path", "")
+        target_path = (
+            lidarr_album_path_val
+            if lidarr_album_path_val and os.path.isdir(lidarr_album_path_val)
+            else dl_album_path
+        )
 
     if not target_path:
         return jsonify({"success": False, "message": "No album path available"}), 400
 
-    config = load_config()
     if not _validate_target_path(target_path, config):
         return jsonify({"success": False, "message": "Invalid target path"}), 400
 
-    makedirs_safe(target_path, [DOWNLOAD_DIR, config.get("lidarr_path", "")])
+    makedirs_safe(target_path, [DOWNLOAD_DIR, lidarr_path])
 
     return _execute_manual_download(
         youtube_url,
@@ -1049,6 +1078,7 @@ def api_download_manual():
         album_id_ctx,
         failed_ctx,
         config,
+        lidarr_path=lidarr_path,
     )
 
 
@@ -1139,7 +1169,11 @@ def _execute_manual_download(
     album_id_ctx,
     failed_ctx,
     config,
+    lidarr_path="",
 ):
+    # lidarr_album_path: set to target_path when a lidarr_path is configured
+    # so that the DB record points at the correct music-library location.
+    lidarr_album_path_rec = target_path if lidarr_path else ""
     return _execute_manual_dl(
         youtube_url=youtube_url,
         track_title=track_title,
@@ -1147,11 +1181,14 @@ def _execute_manual_download(
         target_path=target_path,
         album_data=album_data,
         album_id=album_id_ctx,
-        album_title=failed_ctx.get("album_title", ""),
-        artist_name=failed_ctx.get("artist_name", ""),
+        album_title=failed_ctx.get("album_title", "") or album_data.get("title", ""),
+        artist_name=(
+            failed_ctx.get("artist_name", "")
+            or album_data.get("artist", {}).get("artistName", "")
+        ),
         config=config,
-        album_path=failed_ctx.get("album_path", ""),
-        lidarr_album_path=failed_ctx.get("lidarr_album_path", ""),
+        album_path=target_path,
+        lidarr_album_path=lidarr_album_path_rec,
         cover_url=failed_ctx.get("cover_url", ""),
     )
 
@@ -1193,9 +1230,9 @@ def api_manual_track_download(album_id):
     sanitized_artist = sanitize_filename(artist_name)
     sanitized_album = sanitize_filename(album_title)
     if release_year:
-        album_folder = f"{sanitized_album} ({release_year}) [{album_type}]"
+        album_folder = f"{sanitized_album} ({release_year})"
     else:
-        album_folder = f"{sanitized_album} [{album_type}]"
+        album_folder = sanitized_album
 
     config = load_config()
     lidarr_path = config.get("lidarr_path", "")
@@ -1238,17 +1275,18 @@ def api_manual_track_download(album_id):
 
 
 def _build_ydl_opts(config, temp_file):
+    audio_format = config.get("audio_format", "mp3")
+    pp = {
+        "key": "FFmpegExtractAudio",
+        "preferredcodec": audio_format,
+    }
+    if audio_format == "mp3":
+        pp["preferredquality"] = "320"
     opts = {
         "quiet": True,
         "no_warnings": True,
         "format": "bestaudio/best",
-        "postprocessors": [
-            {
-                "key": "FFmpegExtractAudio",
-                "preferredcodec": "mp3",
-                "preferredquality": "320",
-            }
-        ],
+        "postprocessors": [pp],
         "outtmpl": temp_file,
         "noplaylist": True,
     }
@@ -1367,12 +1405,13 @@ def _do_manual_dl(
 
     track_state = download_process["tracks"][0]
 
-    sanitized_track = werkzeug_secure_filename(sanitize_filename(track_title))
+    sanitized_track = sanitize_filename(track_title)
     if not sanitized_track:
         sanitized_track = "untitled"
     temp_file = os.path.join(target_path, f"temp_manual_{uuid.uuid4().hex[:8]}")
+    audio_ext = config.get("audio_format", "mp3")
     final_file = os.path.join(
-        target_path, f"{int(track_num):02d} - {sanitized_track}.mp3"
+        target_path, f"{int(track_num):02d} - {sanitized_track}.{audio_ext}"
     )
 
     real_final = os.path.realpath(final_file)
@@ -1409,7 +1448,7 @@ def _do_manual_dl(
         track_state["error_message"] = str(e)[:200]
         return
 
-    actual_file = temp_file + ".mp3"
+    actual_file = temp_file + f".{audio_ext}"
     if not os.path.exists(actual_file):
         _cleanup_temp_files(temp_file)
         track_state["status"] = "failed"
@@ -1495,12 +1534,13 @@ def _execute_manual_dl(
 ):
     import yt_dlp
 
-    sanitized_track = werkzeug_secure_filename(sanitize_filename(track_title))
+    sanitized_track = sanitize_filename(track_title)
     if not sanitized_track:
         sanitized_track = "untitled"
+    audio_ext = config.get("audio_format", "mp3")
     temp_file = os.path.join(target_path, f"temp_manual_{uuid.uuid4().hex[:8]}")
     final_file = os.path.join(
-        target_path, f"{int(track_num):02d} - {sanitized_track}.mp3"
+        target_path, f"{int(track_num):02d} - {sanitized_track}.{audio_ext}"
     )
 
     real_final = os.path.realpath(final_file)
@@ -1527,7 +1567,7 @@ def _execute_manual_dl(
         _cleanup_temp_files(temp_file)
         return jsonify({"success": False, "message": str(e)[:200]}), 500
 
-    actual_file = temp_file + ".mp3"
+    actual_file = temp_file + f".{audio_ext}"
     if not os.path.exists(actual_file):
         _cleanup_temp_files(temp_file)
         return jsonify(

--- a/app.py
+++ b/app.py
@@ -55,7 +55,7 @@ log.setLevel(logging.ERROR)
 
 app = Flask(__name__)
 
-VERSION = "1.6.6"
+VERSION = "1.6.7"
 
 DOWNLOAD_DIR = os.getenv("DOWNLOAD_PATH", "")
 

--- a/app.py
+++ b/app.py
@@ -1034,9 +1034,6 @@ def api_download_manual():
     config = load_config()
     lidarr_path = config.get("lidarr_path", "")
 
-    # Recompute the correct album folder from current album metadata.
-    # The lidarr_album_path stored in the DB is often "" because it is
-    # recorded before _copy_to_lidarr() runs, so we can't rely on it.
     artist_name_meta = album_data.get("artist", {}).get("artistName", "")
     album_title_meta = album_data.get("title", "")
     release_year_meta = str(album_data.get("releaseDate", ""))[:4]
@@ -1052,7 +1049,6 @@ def api_download_manual():
     elif DOWNLOAD_DIR:
         target_path = os.path.join(DOWNLOAD_DIR, san_artist, album_folder_meta)
     else:
-        # Last resort: fall back to whatever the DB has
         lidarr_album_path_val = failed_ctx.get("lidarr_album_path", "")
         dl_album_path = failed_ctx.get("album_path", "")
         target_path = (
@@ -1171,8 +1167,6 @@ def _execute_manual_download(
     config,
     lidarr_path="",
 ):
-    # lidarr_album_path: set to target_path when a lidarr_path is configured
-    # so that the DB record points at the correct music-library location.
     lidarr_album_path_rec = target_path if lidarr_path else ""
     return _execute_manual_dl(
         youtube_url=youtube_url,

--- a/processing.py
+++ b/processing.py
@@ -291,11 +291,9 @@ def process_album_download(album_id, force=False):
 
         artist_path = os.path.join(DOWNLOAD_DIR, sanitized_artist)
         if release_year:
-            album_folder_name = (
-                f"{sanitized_album} ({release_year}) [{album_type}]"
-            )
+            album_folder_name = f"{sanitized_album} ({release_year})"
         else:
-            album_folder_name = f"{sanitized_album} [{album_type}]"
+            album_folder_name = sanitized_album
         album_path = os.path.join(artist_path, album_folder_name)
         try:
             makedirs_safe(album_path, [DOWNLOAD_DIR])

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -1154,6 +1154,25 @@
             text-decoration: line-through;
             opacity: 0.5;
         }
+
+        .btn-retry-failed {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.3rem;
+            padding: 0.3rem 0.7rem;
+            border: 1px solid #f59e0b;
+            color: #f59e0b;
+            border-radius: 8px;
+            font-size: 0.78rem;
+            font-weight: 600;
+            text-decoration: none;
+            white-space: nowrap;
+            flex-shrink: 0;
+            transition: all 0.2s;
+        }
+        .btn-retry-failed:hover {
+            background: rgba(245, 158, 11, 0.15);
+        }
     </style>
 </head>
 
@@ -1732,6 +1751,19 @@
             badge.className = 'history-track-badge ' + badgeClass;
             badge.textContent = item.success_count + '/' + item.total_count + ' tracks';
             row.appendChild(badge);
+
+            if (status === 'partial' || status === 'error') {
+                const retryBtn = document.createElement('a');
+                retryBtn.href = '/?retry=' + albumId;
+                retryBtn.className = 'btn-retry-failed';
+                retryBtn.title = 'Search and manually download failed tracks';
+                retryBtn.addEventListener('click', function(e) { e.stopPropagation(); });
+                const retryIcon = document.createElement('i');
+                retryIcon.className = 'fa-solid fa-magnifying-glass';
+                retryBtn.appendChild(retryIcon);
+                retryBtn.appendChild(document.createTextNode(' Retry'));
+                row.appendChild(retryBtn);
+            }
 
             wrapper.appendChild(row);
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -2804,11 +2804,16 @@
 
         (async () => {
           try {
-            const res = await fetch("/api/download/failed");
+            const params = new URLSearchParams(window.location.search);
+            const retryParam = params.get("retry");
+            const retryAlbumId = retryParam && retryParam !== "1" ? retryParam : null;
+            const url = retryAlbumId
+              ? "/api/download/failed?album_id=" + encodeURIComponent(retryAlbumId)
+              : "/api/download/failed";
+            const res = await fetch(url);
             const data = await res.json();
             if (data.failed_tracks && data.failed_tracks.length > 0) {
-              const openOverlay =
-                new URLSearchParams(window.location.search).get("retry") === "1";
+              const openOverlay = !!retryParam;
               showFailedTracksOverlay(data, openOverlay);
               if (openOverlay)
                 history.replaceState(null, "", window.location.pathname);


### PR DESCRIPTION
## Summary
This PR adds support for configurable audio formats (mp3, opus, flac, aac, ogg, m4a) throughout the application and improves the failed track retry workflow by allowing users to retry specific albums directly from the downloads list.

## Key Changes

- **Configurable Audio Format Support**
  - Modified `_build_ydl_opts()` to use `audio_format` from config instead of hardcoded mp3
  - Updated track deletion logic to search for audio files with multiple extensions, prioritizing the configured format
  - Updated manual download functions to use the configured audio format for final file naming
  - Removed hardcoded `.mp3` extensions and replaced with dynamic format from config

- **Improved Failed Track Retry Workflow**
  - Modified `/api/download/failed` endpoint to accept optional `album_id` query parameter for retrying specific albums
  - Added "Retry" button to failed/partial downloads in the downloads list that links directly to retry that album
  - Updated frontend to pass album_id when retrying from downloads page
  - Improved failed tracks overlay to handle both generic and album-specific retry requests

- **Album Folder Naming Simplification**
  - Removed `[album_type]` suffix from album folder names in both `app.py` and `processing.py`
  - Album folders now use format: `{album_name} ({year})` or just `{album_name}` if year unavailable

- **Manual Download Path Resolution Enhancement**
  - Improved `api_download_manual()` to construct target path from metadata (artist/album/year) when lidarr_path or DOWNLOAD_DIR is configured
  - Falls back to stored paths only when primary paths are unavailable
  - Ensures consistent path construction between initial download and retry scenarios

- **Code Quality Improvements**
  - Removed unnecessary `werkzeug_secure_filename()` calls (sanitize_filename already handles this)
  - Improved error handling in track deletion with better logging
  - Refactored postprocessor configuration for better readability

## Notable Implementation Details

- Audio format detection prioritizes configured format first, then falls back to other supported formats when deleting files
- Failed track retry now preserves album context by passing album_id through URL parameters
- Path construction logic now prefers metadata-based paths over stored database paths for consistency