### PR TITLE
Fix config default, cap YouTube candidates, and ensure download directory creation

### DIFF
--- a/config.py
+++ b/config.py
@@ -27,7 +27,7 @@ ALLOWED_CONFIG_KEYS = {
     "min_match_score", "audio_format",
 }
 
-MIN_MATCH_SCORE_DEFAULT = 0.7
+MIN_MATCH_SCORE_DEFAULT = 0.8
 
 
 def _parse_min_match_score(value):

--- a/downloader.py
+++ b/downloader.py
@@ -168,7 +168,7 @@ def _build_common_opts(player_client=None):
     return opts
 
 
-MAX_CANDIDATES = 15
+MAX_CANDIDATES = 10
 
 
 def search_youtube_candidates(

--- a/utils.py
+++ b/utils.py
@@ -63,6 +63,7 @@ def get_umask():
 
 
 def makedirs_within(base_dir, target_path):
+    os.makedirs(base_dir, exist_ok=True)
     try:
         rel = os.path.relpath(target_path, base_dir)
     except ValueError:


### PR DESCRIPTION
### Motivation

- Tests revealed three regressions: the `min_match_score` fallback default was incorrect, YouTube search returned too many candidates, and manual downloads could fail when the base download directory did not yet exist. 

### Description

- Restore `MIN_MATCH_SCORE_DEFAULT` to `0.8` in `config.py` so invalid or out-of-range values fall back to the expected default. 
- Limit YouTube search results by changing `MAX_CANDIDATES` from `15` to `10` in `downloader.py` to match intended behavior. 
- Ensure base directories are created before nested directories by calling `os.makedirs(base_dir, exist_ok=True)` at the start of `makedirs_within` in `utils.py` to prevent `FileNotFoundError` during manual downloads. 

### Testing

- Ran the failing test cases directly with `pytest -q tests/test_config.py::test_min_match_score_invalid_env_falls_back tests/test_config.py::test_min_match_score_out_of_range_falls_back tests/test_config.py::test_min_match_score_invalid_in_file_falls_back tests/test_downloader.py::TestSearchYoutubeCandidates::test_caps_at_10_candidates tests/test_routes.py::TestManualTrackDownload::test_successful_download` and they passed. 
- Ran the full test suite with `pytest -q` and all tests passed (`418 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c38628d808326850a00c2e5c33e4f)