### PR TITLE
fix(cookies): add cookies UI, upload endpoint, and startup validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -818,6 +818,73 @@ def api_cover_art_toggle():
     return jsonify({"enabled": config["save_cover_art_file"]})
 
 
+COOKIES_UPLOAD_PATH = "/config/cookies.txt"
+
+
+@app.route("/api/cookies/check", methods=["GET"])
+def api_cookies_check():
+    config = load_config()
+    cookies_path = (config.get("yt_cookies_file") or "").strip()
+    if not cookies_path:
+        return jsonify({"configured": False, "exists": False, "path": ""})
+    exists = os.path.exists(cookies_path)
+    size = os.path.getsize(cookies_path) if exists else 0
+    return jsonify({"configured": True, "exists": exists, "path": cookies_path, "size": size})
+
+
+@app.route("/api/cookies/upload", methods=["POST"])
+def api_cookies_upload():
+    client_ip = request.remote_addr or "unknown"
+    if not check_rate_limit(
+        f"cookies_upload:{client_ip}", rate_limit_store, window=30, max_requests=5
+    ):
+        return jsonify({"success": False, "message": "Too many requests"}), 429
+    if "file" not in request.files:
+        return jsonify({"success": False, "message": "No file provided"}), 400
+    file = request.files["file"]
+    if not file.filename:
+        return jsonify({"success": False, "message": "No file selected"}), 400
+    try:
+        content = file.read()
+        text = content.decode("utf-8")
+    except (UnicodeDecodeError, OSError) as e:
+        return jsonify({"success": False, "message": f"Could not read file: {e}"}), 400
+    if not any(
+        line.strip().startswith("# Netscape HTTP Cookie File")
+        or "\t" in line
+        for line in text.splitlines()[:5]
+    ):
+        return jsonify(
+            {"success": False, "message": "File does not look like a Netscape cookies.txt"}
+        ), 400
+    try:
+        os.makedirs(os.path.dirname(COOKIES_UPLOAD_PATH), exist_ok=True)
+        with open(COOKIES_UPLOAD_PATH, "w", encoding="utf-8") as f:
+            f.write(text)
+    except OSError as e:
+        return jsonify({"success": False, "message": f"Could not save file: {e}"}), 500
+    config = load_config()
+    config["yt_cookies_file"] = COOKIES_UPLOAD_PATH
+    save_config(config)
+    logger.info("Cookies file uploaded and saved to %s", COOKIES_UPLOAD_PATH)
+    return jsonify({"success": True, "path": COOKIES_UPLOAD_PATH, "size": len(content)})
+
+
+@app.route("/api/cookies/delete", methods=["POST"])
+def api_cookies_delete():
+    config = load_config()
+    cookies_path = (config.get("yt_cookies_file") or "").strip()
+    if cookies_path and os.path.exists(cookies_path):
+        try:
+            os.remove(cookies_path)
+        except OSError as e:
+            return jsonify({"success": False, "message": f"Could not delete file: {e}"}), 500
+    config["yt_cookies_file"] = ""
+    save_config(config)
+    logger.info("Cookies file removed")
+    return jsonify({"success": True})
+
+
 @app.route("/api/youtube/search", methods=["POST"])
 def api_youtube_search():
     client_ip = request.remote_addr or "unknown"
@@ -842,6 +909,8 @@ def api_youtube_search():
     cookies_path = (config.get("yt_cookies_file") or "").strip()
     if cookies_path and os.path.exists(cookies_path):
         ydl_opts["cookiefile"] = cookies_path
+    elif cookies_path:
+        logger.warning("YouTube cookies file not found: %s", cookies_path)
     if config.get("yt_force_ipv4", True):
         ydl_opts["source_address"] = "0.0.0.0"
     pc = config.get("yt_player_client", "android")
@@ -942,6 +1011,8 @@ def api_youtube_stream():
         cookies_path = (config.get("yt_cookies_file") or "").strip()
         if cookies_path and os.path.exists(cookies_path):
             ydl_opts["cookiefile"] = cookies_path
+        elif cookies_path:
+            logger.warning("YouTube cookies file not found: %s", cookies_path)
         if config.get("yt_force_ipv4", True):
             ydl_opts["source_address"] = "0.0.0.0"
         pc = config.get("yt_player_client", "android")
@@ -1322,6 +1393,8 @@ def _build_ydl_opts(config, temp_file):
     cookies_path = (config.get("yt_cookies_file") or "").strip()
     if cookies_path and os.path.exists(cookies_path):
         opts["cookiefile"] = cookies_path
+    elif cookies_path:
+        logger.warning("YouTube cookies file not found: %s", cookies_path)
     if config.get("yt_force_ipv4", True):
         opts["source_address"] = "0.0.0.0"
     pc = config.get("yt_player_client", "android")
@@ -1908,6 +1981,8 @@ def api_youtube_playlist_info():
     cookies_path = (config.get("yt_cookies_file") or "").strip()
     if cookies_path and os.path.exists(cookies_path):
         ydl_opts["cookiefile"] = cookies_path
+    elif cookies_path:
+        logger.warning("YouTube cookies file not found: %s", cookies_path)
     if config.get("yt_force_ipv4", True):
         ydl_opts["source_address"] = "0.0.0.0"
     pc = config.get("yt_player_client", "android")
@@ -2755,6 +2830,22 @@ def _startup_ytdlp_update():
     _exec_restart()
 
 
+def _startup_cookies_check():
+    config = load_config()
+    cookies_path = (config.get("yt_cookies_file") or "").strip()
+    if not cookies_path:
+        logger.info("YouTube cookies: not configured")
+        return
+    if os.path.exists(cookies_path):
+        size = os.path.getsize(cookies_path)
+        logger.info("YouTube cookies: found at %s (%d bytes)", cookies_path, size)
+    else:
+        logger.warning(
+            "YouTube cookies: configured path does not exist: %s"
+            " — downloads will proceed without cookies", cookies_path
+        )
+
+
 if __name__ == "__main__":
     db.init_db()
     models.reset_downloading_to_queued()
@@ -2764,6 +2855,7 @@ if __name__ == "__main__":
         "Download directory: %s",
         DOWNLOAD_DIR if DOWNLOAD_DIR else "Not set (check DOWNLOAD_PATH env)",
     )
+    _startup_cookies_check()
     setup_scheduler()
     threading.Thread(target=run_scheduler, daemon=True).start()
     threading.Thread(target=process_download_queue, daemon=True).start()

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -978,6 +978,50 @@
 
         <div class="settings-section">
             <div class="section-header">
+                <i class="fa-solid fa-cookie-bite"></i>
+                <h2>YouTube Cookies</h2>
+            </div>
+            <div class="input-group">
+                <label>
+                    Cookies Status
+                    <div class="label-description">Required if YouTube asks for sign-in. Export cookies from your browser using a browser extension (e.g. "Get cookies.txt LOCALLY") while logged in to YouTube.</div>
+                </label>
+                <div id="cookiesStatus" style="display:flex; align-items:center; gap:0.75rem; padding:0.75rem 1rem; background:var(--bg); border:1px solid var(--border); border-radius:10px; margin-top:0.25rem;">
+                    <span id="cookiesStatusDot" style="width:10px;height:10px;border-radius:50%;background:#71717a;flex-shrink:0;"></span>
+                    <span id="cookiesStatusText" style="font-size:0.85rem;color:var(--text-dim);">Checking...</span>
+                </div>
+            </div>
+            <div class="input-group">
+                <label>
+                    Cookies File Path
+                    <div class="label-description">Absolute path inside the container to a Netscape cookies.txt file. When you upload a file below it is automatically saved to <code>/config/cookies.txt</code> and this field is updated.</div>
+                </label>
+                <div style="display:flex;gap:0.5rem;align-items:center;">
+                    <input type="text" id="cookiesFilePath" placeholder="/config/cookies.txt" style="flex:1;">
+                    <button class="btn" onclick="saveCookiesPath()" style="padding:0.5rem 1rem;font-size:0.85rem;white-space:nowrap;width:auto;">
+                        <i class="fa-solid fa-floppy-disk"></i> Save Path
+                    </button>
+                </div>
+            </div>
+            <div class="input-group">
+                <label>
+                    Upload cookies.txt
+                    <div class="label-description">Upload a Netscape-format cookies.txt file. It will be saved to <code>/config/cookies.txt</code> inside the container.</div>
+                </label>
+                <div style="display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;">
+                    <input type="file" id="cookiesFileInput" accept=".txt,text/plain" style="display:none;" onchange="uploadCookiesFile(this)">
+                    <button class="btn" onclick="document.getElementById('cookiesFileInput').click()" style="padding:0.5rem 1rem;font-size:0.85rem;white-space:nowrap;width:auto;">
+                        <i class="fa-solid fa-upload"></i> Upload cookies.txt
+                    </button>
+                    <button class="btn" id="deleteCookiesBtn" onclick="deleteCookies()" style="padding:0.5rem 1rem;font-size:0.85rem;white-space:nowrap;width:auto;background:rgba(239,68,68,0.15);border-color:rgba(239,68,68,0.3);color:#ef4444;" title="Remove cookies file and clear the configured path">
+                        <i class="fa-solid fa-trash"></i> Remove Cookies
+                    </button>
+                </div>
+            </div>
+        </div>
+
+        <div class="settings-section">
+            <div class="section-header">
                 <i class="fa-brands fa-telegram"></i>
                 <h2>Telegram Notifications</h2>
             </div>
@@ -1255,9 +1299,86 @@
                     ? conf.scheduler_retry_after_hours
                     : 24
             );
+            document.getElementById('cookiesFilePath').value = conf.yt_cookies_file || '';
             // Defer clearing so any change events from programmatic
             // assignments above don't immediately re-mark dirty.
             setTimeout(() => { _suppressDirty = false; clearSettingsDirty(); }, 0);
+            loadCookiesStatus();
+        }
+
+        async function loadCookiesStatus() {
+            try {
+                const res = await fetch('/api/cookies/check');
+                const data = await res.json();
+                const dot = document.getElementById('cookiesStatusDot');
+                const text = document.getElementById('cookiesStatusText');
+                if (!data.configured) {
+                    dot.style.background = '#71717a';
+                    text.textContent = 'No cookies configured — YouTube may block downloads';
+                    text.style.color = 'var(--text-dim)';
+                } else if (data.exists) {
+                    dot.style.background = '#10b981';
+                    const kb = Math.round(data.size / 1024);
+                    text.textContent = `Cookies loaded: ${data.path} (${kb} KB)`;
+                    text.style.color = '#10b981';
+                } else {
+                    dot.style.background = '#ef4444';
+                    text.textContent = `File not found: ${data.path}`;
+                    text.style.color = '#ef4444';
+                }
+            } catch {
+                document.getElementById('cookiesStatusText').textContent = 'Error checking cookies status';
+            }
+        }
+
+        async function saveCookiesPath() {
+            const path = document.getElementById('cookiesFilePath').value.trim();
+            const res = await fetch('/api/config', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({yt_cookies_file: path}),
+            });
+            const data = await res.json();
+            if (data.success) {
+                showToast('success', 'Saved', 'Cookies file path updated');
+                loadCookiesStatus();
+            } else {
+                showToast('error', 'Save Failed', 'Could not save cookies path');
+            }
+        }
+
+        async function uploadCookiesFile(input) {
+            const file = input.files[0];
+            if (!file) return;
+            const formData = new FormData();
+            formData.append('file', file);
+            try {
+                const res = await fetch('/api/cookies/upload', {method: 'POST', body: formData});
+                const data = await res.json();
+                if (data.success) {
+                    document.getElementById('cookiesFilePath').value = data.path;
+                    showToast('success', 'Cookies Uploaded', `Saved to ${data.path}`);
+                    loadCookiesStatus();
+                } else {
+                    showToast('error', 'Upload Failed', data.message || 'Unknown error');
+                }
+            } catch {
+                showToast('error', 'Upload Failed', 'Network error');
+            }
+            input.value = '';
+        }
+
+        async function deleteCookies() {
+            if (!confirm('Remove the cookies file and clear the configured path?')) return;
+            const res = await fetch('/api/cookies/delete', {method: 'POST'});
+            const data = await res.json();
+            if (data.success) {
+                document.getElementById('cookiesFilePath').value = '';
+                showToast('success', 'Cookies Removed', 'Cookies file deleted and path cleared');
+                loadCookiesStatus();
+            } else {
+                showToast('error', 'Remove Failed', data.message || 'Unknown error');
+            }
         }
 
         function updateSchedulerBtn(enabled) {


### PR DESCRIPTION
 #60 — YouTube cookies were silently ignored when the configured
file path did not exist inside the container, giving users no feedback.

Changes:
- Add /api/cookies/check endpoint (GET) — returns configured path,
  whether the file exists, and its size
- Add /api/cookies/upload endpoint (POST) — accepts a Netscape
  cookies.txt upload, saves it to /config/cookies.txt, and updates
  yt_cookies_file in config automatically
- Add /api/cookies/delete endpoint (POST) — removes the file and
  clears the config key
- Fix four silent-failure sites in app.py where a missing cookie file
  was skipped without any warning; each now logs a warning when the
  configured path does not exist
- Add _startup_cookies_check() called at startup to log whether the
  cookie file is found or missing
- Add "YouTube Cookies" section to settings.html with status indicator
  (green/grey/red), path input with Save button, Upload cookies.txt
  button, and Remove Cookies button

https://claude.ai/code/session_01DEFBE3stj2Ey7xTXHHrdBj