### PR TITLE
Allowlist YouTube URLs in the format-listing endpoint (SSRF)

### DIFF
--- a/app.py
+++ b/app.py
@@ -579,8 +579,17 @@ def api_ytdlp_formats():
         return jsonify(
             {"success": False, "message": "Enter a YouTube video URL or ID"}
         )
+    # Allowlist YouTube hosts / bare ids before handing the URL to yt-dlp's
+    # generic extractor, so this settings helper can't be used to probe
+    # internal services (SSRF).
+    safe_url = _validate_youtube_url(url)
+    if not safe_url:
+        return jsonify({
+            "success": False,
+            "message": "Enter a valid YouTube video URL or 11-character ID",
+        })
     try:
-        result = list_video_formats(url)
+        result = list_video_formats(safe_url)
     except Exception as e:
         return jsonify({"success": False, "message": str(e)[:240]})
     if not result.get("formats"):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1821,7 +1821,53 @@ class TestYtdlpFormatsRoute:
             raise Exception("Video unavailable")
         monkeypatch.setattr("app.list_video_formats", boom)
         data = client.post(
-            "/api/ytdlp/formats", json={"url": "x"}
+            "/api/ytdlp/formats", json={"url": "dQw4w9WgXcQ"}
         ).get_json()
         assert data["success"] is False
         assert "unavailable" in data["message"].lower()
+
+    def test_rejects_non_youtube_url(self, client, monkeypatch):
+        # SSRF guard: a non-YouTube URL must be refused before yt-dlp is
+        # ever invoked.
+        calls = []
+        monkeypatch.setattr(
+            "app.list_video_formats", lambda url: calls.append(url)
+        )
+        data = client.post(
+            "/api/ytdlp/formats",
+            json={"url": "http://localhost:8080/admin"},
+        ).get_json()
+        assert data["success"] is False
+        assert calls == []
+
+    def test_accepts_music_youtube_url(self, client, monkeypatch):
+        received = []
+
+        def fake(url):
+            received.append(url)
+            return {"title": "Song", "formats": [{
+                "format_id": "141", "ext": "m4a", "acodec": "mp4a",
+                "abr": 256, "filesize": 0, "audio_only": True, "note": "",
+            }]}
+        monkeypatch.setattr("app.list_video_formats", fake)
+        data = client.post(
+            "/api/ytdlp/formats",
+            json={"url": "https://music.youtube.com/watch?v=DIEI2YLYg6o"},
+        ).get_json()
+        assert data["success"] is True
+        assert received == [
+            "https://music.youtube.com/watch?v=DIEI2YLYg6o"
+        ]
+
+    def test_bare_id_is_normalized_before_listing(self, client, monkeypatch):
+        received = []
+
+        def fake(url):
+            received.append(url)
+            return {"title": "x", "formats": [{
+                "format_id": "140", "ext": "m4a", "acodec": "mp4a",
+                "abr": 128, "filesize": 0, "audio_only": True, "note": "",
+            }]}
+        monkeypatch.setattr("app.list_video_formats", fake)
+        client.post("/api/ytdlp/formats", json={"url": "dQw4w9WgXcQ"})
+        assert received == ["https://www.youtube.com/watch?v=dQw4w9WgXcQ"]


### PR DESCRIPTION
/api/ytdlp/formats handed an arbitrary URL straight to yt-dlp's generic extractor, so a caller could make the server fetch internal services (SSRF) and trigger an expensive extraction. Run the input through the existing _validate_youtube_url allowlist (YouTube hosts / bare 11-char ids only) and pass the normalized URL to list_video_formats, matching the manual download path.