### PR TITLE
 Search YouTube by track artist for compilations and fix API User-Agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ State is stored in SQLite at `/config/lidarr-downloader.db`. Tables: `schema_ver
 
 **`album_id` id space:** a positive `album_id` is a real Lidarr album id. YouTube playlist imports have no Lidarr album, so each import is assigned a **unique negative `album_id`** (`models.next_playlist_album_id()`), keeping its tracks distinct in the history / failed-track retry views. This negative space is disjoint from Lidarr's and must never be joined to Lidarr or sent to the Lidarr API (e.g. `download_client.py` assumes positive ids). Retry resolves a negative id's context from the stored `track_downloads` row instead of Lidarr.
 
-Current schema version: **8**. Migrations:
+Current schema version: **9**. Migrations:
 - V1→V2: Replaced `download_history` + `failed_tracks` with `track_downloads` (per-track download records with YouTube URL, match score, duration, album/track metadata).
 - V2→V3: Added AcoustID fingerprint columns to `track_downloads` (`acoustid_fingerprint_id`, `acoustid_score`, `acoustid_recording_id`, `acoustid_recording_title`).
 - V3→V4: Added `banned_urls` table for tracking banned YouTube URLs per album/track.
@@ -110,6 +110,7 @@ Current schema version: **8**. Migrations:
 - V5→V6: Added `missing_albums_cache` and `sync_state` tables for paginated background sync of Lidarr's missing-albums list.
 - V6→V7: Added `download_client_jobs` table so the Lidarr download-client bridge (SABnzbd `nzo_id` jobs) survives restarts; `download_client.restore_jobs()` reloads them at startup and re-queues interrupted downloads.
 - V7→V8: Reassigned pre-existing YouTube playlist imports (recorded under the shared sentinel `album_id = 0`) to unique negative `album_id`s in `track_downloads` and `download_logs`, so old failed playlist tracks become retryable and distinct playlists stop colliding.
+- V8→V9: Added `track_artist` to `track_downloads`, storing the per-track artist resolved via `search_artist_source` (MusicBrainz/iTunes), distinct from the Lidarr album-level `artist_name`, so compilation ("Various Artists") tracks can be searched/retried with their real artist.
 
 Schema is versioned via `schema_version` table. **When changing the DB schema:**
 
@@ -124,7 +125,7 @@ Schema is versioned via `schema_version` table. **When changing the DB schema:**
 
 ### Config
 
-Loaded from env vars + `/config/config.json`. File config overrides env vars. Saved via `save_config()`. `ALLOWED_CONFIG_KEYS` whitelist controls what can be set via the API. Notable config keys beyond the basics: `concurrent_tracks`, `yt_cookies_file`, `yt_force_ipv4`, `yt_player_client`, `yt_retries`, `yt_fragment_retries`, `yt_sleep_requests`, `yt_sleep_interval`, `yt_max_sleep_interval`, `discord_enabled`, `discord_webhook_url`, `discord_log_types`, `acoustid_enabled`, `acoustid_api_key`, `download_client_enabled`, `download_client_api_key`, `download_client_category`, `yt_po_token` (manual yt-dlp PO token(s), comma-separated), `audio_normalize` (EBU R128 loudnorm, forces re-encode), `yt_pot_provider_url` (URL of a bgutil PO-token provider sidecar for automatic PO tokens; `bgutil-ytdlp-pot-provider` plugin is in requirements and a sidecar is wired in docker-compose).
+Loaded from env vars + `/config/config.json`. File config overrides env vars. Saved via `save_config()`. `ALLOWED_CONFIG_KEYS` whitelist controls what can be set via the API. Notable config keys beyond the basics: `concurrent_tracks`, `yt_cookies_file`, `yt_force_ipv4`, `yt_player_client`, `yt_retries`, `yt_fragment_retries`, `yt_sleep_requests`, `yt_sleep_interval`, `yt_max_sleep_interval`, `discord_enabled`, `discord_webhook_url`, `discord_log_types`, `acoustid_enabled`, `acoustid_api_key`, `download_client_enabled`, `download_client_api_key`, `download_client_category`, `yt_po_token` (manual yt-dlp PO token(s), comma-separated), `audio_normalize` (EBU R128 loudnorm, forces re-encode), `yt_pot_provider_url` (URL of a bgutil PO-token provider sidecar for automatic PO tokens; `bgutil-ytdlp-pot-provider` plugin is in requirements and a sidecar is wired in docker-compose), `search_artist_source` (per-track YouTube search artist: `album` default, or `mb_itunes`/`itunes_mb`/`mb`/`itunes` to resolve the real artist for compilations).
 
 ### Lidarr download-client bridge (`download_client.py`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ Standalone scripts not part of the main app:
 
 ## Version Updates
 
-The version string is defined in `app.py`: `VERSION = "1.8.5"`. The README badge also references it and must be updated manually.
+The version string is defined in `version.py`: `VERSION = "1.8.5"`. The README badge also references it and must be updated manually.
 
 ## Persistence Volume
 

--- a/app.py
+++ b/app.py
@@ -56,6 +56,7 @@ from utils import (
     sanitize_filename,
     set_permissions,
 )
+from version import USER_AGENT, VERSION
 
 logging.basicConfig(
     level=logging.INFO, format="%(message)s", handlers=[logging.StreamHandler()]
@@ -67,8 +68,6 @@ log.setLevel(logging.ERROR)
 
 app = Flask(__name__)
 app.register_blueprint(download_client.bp)
-
-VERSION = "1.8.5"
 
 DOWNLOAD_DIR = os.getenv("DOWNLOAD_PATH", "")
 
@@ -3347,7 +3346,7 @@ def _get_ytdlp_pypi_version():
     try:
         resp = http_requests.get(
             "https://pypi.org/pypi/yt-dlp/json",
-            headers={"User-Agent": "lidarr-yt-downloader"},
+            headers={"User-Agent": USER_AGENT},
             timeout=10,
         )
         resp.raise_for_status()

--- a/config.py
+++ b/config.py
@@ -57,7 +57,15 @@ ALLOWED_CONFIG_KEYS = {
     "download_client_category", "download_client_concurrent_albums",
     "yt_po_token", "audio_normalize", "yt_pot_provider_url",
     "playlist_to_library",
+    "search_artist_source",
 }
+
+# Valid values for search_artist_source: which artist to use when building
+# the YouTube search query for a track. "album" (default) is Lidarr's
+# album-level artist (cheap, but wrong for compilations tagged "Various
+# Artists"); the others resolve a real per-track artist via MusicBrainz
+# and/or iTunes before falling back to "album".
+SEARCH_ARTIST_SOURCES = {"album", "mb_itunes", "itunes_mb", "mb", "itunes"}
 
 MIN_MATCH_SCORE_DEFAULT = 0.8
 
@@ -193,6 +201,7 @@ def load_config():
         "min_match_score": _parse_min_match_score(
             os.getenv("MIN_MATCH_SCORE", "0.8"),
         ),
+        "search_artist_source": os.getenv("SEARCH_ARTIST_SOURCE", "album"),
         "audio_format": os.getenv("AUDIO_FORMAT", "mp3"),
         "audio_quality": os.getenv("AUDIO_QUALITY", "320"),
         # Optional yt-dlp format selector override (e.g. "141" for 256 kbps
@@ -281,6 +290,9 @@ def load_config():
     except (TypeError, ValueError):
         _cca = 1
     config["download_client_concurrent_albums"] = max(1, min(5, _cca))
+
+    if config.get("search_artist_source") not in SEARCH_ARTIST_SOURCES:
+        config["search_artist_source"] = "album"
 
     def norm(p):
         return (

--- a/db.py
+++ b/db.py
@@ -9,7 +9,7 @@ import time
 logger = logging.getLogger(__name__)
 
 DB_PATH = "/config/lidarr-downloader.db"
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 _local = threading.local()
 
@@ -463,6 +463,20 @@ def _migrate_v7_to_v8(conn):
         next_id -= 1
 
 
+def _migrate_v8_to_v9(conn):
+    """Add track_artist to track_downloads.
+
+    Stores the per-track artist resolved for the search query (MusicBrainz
+    recording artist-credit and/or iTunes), distinct from the Lidarr
+    album-level artist_name column, so compilation ("Various Artists")
+    tracks can be searched and retried with their real artist.
+    """
+    conn.execute(
+        "ALTER TABLE track_downloads"
+        " ADD COLUMN track_artist TEXT DEFAULT ''"
+    )
+
+
 def _run_migrations(conn, current_version):
     """Run any pending schema migrations sequentially."""
     migrations = {
@@ -473,6 +487,7 @@ def _run_migrations(conn, current_version):
         6: _migrate_v5_to_v6,
         7: _migrate_v6_to_v7,
         8: _migrate_v7_to_v8,
+        9: _migrate_v8_to_v9,
     }
     for version in sorted(migrations):
         if current_version < version:

--- a/fingerprint.py
+++ b/fingerprint.py
@@ -14,9 +14,12 @@ import time
 
 import requests
 
+from version import USER_AGENT
+
 logger = logging.getLogger(__name__)
 
 ACOUSTID_API_URL = "https://api.acoustid.org/v2/lookup"
+ACOUSTID_HEADERS = {"User-Agent": USER_AGENT}
 RATE_LIMIT_INTERVAL = 0.34  # ~3 requests per second
 
 _last_request_time = 0.0
@@ -79,7 +82,9 @@ def _lookup_acoustid(api_key, duration, fingerprint):
     }
     try:
         _throttle()
-        r = requests.post(ACOUSTID_API_URL, data=params, timeout=15)
+        r = requests.post(
+            ACOUSTID_API_URL, data=params, headers=ACOUSTID_HEADERS, timeout=15
+        )
         if not r.ok:
             logger.warning(
                 "AcoustID API returned %d: %s",

--- a/metadata.py
+++ b/metadata.py
@@ -31,8 +31,13 @@ from mutagen.oggopus import OggOpus
 
 from lidarr import get_monitored_release
 from utils import sanitize_filename
+from version import USER_AGENT
 
 logger = logging.getLogger(__name__)
+
+# Identifying User-Agent for the MusicBrainz family of APIs (musicbrainz.org,
+# coverartarchive.org), which reject or throttle the default requests one.
+_API_HEADERS = {"User-Agent": USER_AGENT}
 
 
 def tag_mp3(file_path, track_info, album_info, cover_data):
@@ -488,8 +493,7 @@ def _musicbrainz_release_id(artist, album):
             "fmt": "json",
             "limit": 5,
         }
-        headers = {"User-Agent": "Lidarr-YouTube-Downloader/1.7"}
-        r = requests.get(url, params=params, headers=headers, timeout=10)
+        r = requests.get(url, params=params, headers=_API_HEADERS, timeout=10)
         data = r.json() or {}
         releases = data.get("releases", []) or []
         artist_lower = (artist or "").lower()
@@ -535,8 +539,7 @@ def get_musicbrainz_recording_artist(recording_id):
         _musicbrainz_throttle()
         url = f"https://musicbrainz.org/ws/2/recording/{recording_id}"
         params = {"fmt": "json", "inc": "artist-credits"}
-        headers = {"User-Agent": "Lidarr-YouTube-Downloader/1.7"}
-        r = requests.get(url, params=params, headers=headers, timeout=10)
+        r = requests.get(url, params=params, headers=_API_HEADERS, timeout=10)
         data = r.json() or {}
         credits = data.get("artist-credit", []) or []
         name = "".join(
@@ -565,7 +568,9 @@ def get_cover_art_archive_artwork(artist, album):
         cover_url = (
             f"https://coverartarchive.org/release/{release_id}/front"
         )
-        r = requests.get(cover_url, timeout=15, allow_redirects=True)
+        r = requests.get(
+            cover_url, headers=_API_HEADERS, timeout=15, allow_redirects=True
+        )
         if r.status_code == 200 and r.content:
             return r.content
     except Exception as e:

--- a/metadata.py
+++ b/metadata.py
@@ -7,6 +7,8 @@ Lidarr import, and iTunes API lookups for track lists and album artwork.
 import base64
 import logging
 import os
+import threading
+import time
 from xml.sax.saxutils import escape as xml_escape
 
 import requests
@@ -349,6 +351,7 @@ def get_itunes_tracks(artist, album_name):
                     {
                         "trackNumber": item.get("trackNumber"),
                         "title": item.get("trackName"),
+                        "artist": item.get("artistName"),
                         "previewUrl": item.get("previewUrl"),
                         "hasFile": False,
                     }
@@ -453,9 +456,32 @@ def get_deezer_artwork(artist, album):
     return None
 
 
+_mb_rate_lock = threading.Lock()
+_mb_last_request_time = 0.0
+_MB_MIN_INTERVAL = 1.0
+
+
+def _musicbrainz_throttle():
+    """Space out MusicBrainz requests to at most 1 per second.
+
+    MusicBrainz throttles by source IP address: once a client's request
+    rate is measured too high, *all* of its requests get declined with
+    HTTP 503 until the rate drops again, and that measured rate is
+    currently ~1 request/second on average.
+    source: https://musicbrainz.org/doc/MusicBrainz_API/Rate_Limiting
+    """
+    global _mb_last_request_time
+    with _mb_rate_lock:
+        wait = _mb_last_request_time + _MB_MIN_INTERVAL - time.monotonic()
+        if wait > 0:
+            time.sleep(wait)
+        _mb_last_request_time = time.monotonic()
+
+
 def _musicbrainz_release_id(artist, album):
     """Resolve a MusicBrainz release id (uuid) for artist+album, or None."""
     try:
+        _musicbrainz_throttle()
         url = "https://musicbrainz.org/ws/2/release/"
         params = {
             "query": f'artist:"{artist}" AND release:"{album}"',
@@ -489,6 +515,38 @@ def _musicbrainz_release_id(artist, album):
             return releases[0].get("id") or None
     except Exception as e:
         logger.debug(f"MusicBrainz lookup failed: {e}")
+    return None
+
+
+def get_musicbrainz_recording_artist(recording_id):
+    """Resolve a MusicBrainz recording's artist-credit name.
+
+    Used to find the real per-track artist for compilation albums, where
+    Lidarr's album-level artist is "Various Artists" but each track's
+    MusicBrainz recording (``foreignRecordingId``) has its own credited
+    artist(s).
+
+    Returns the artist-credit phrase (e.g. "Artist A feat. Artist B"), or
+    None if unresolvable.
+    """
+    if not recording_id:
+        return None
+    try:
+        _musicbrainz_throttle()
+        url = f"https://musicbrainz.org/ws/2/recording/{recording_id}"
+        params = {"fmt": "json", "inc": "artist-credits"}
+        headers = {"User-Agent": "Lidarr-YouTube-Downloader/1.7"}
+        r = requests.get(url, params=params, headers=headers, timeout=10)
+        data = r.json() or {}
+        credits = data.get("artist-credit", []) or []
+        name = "".join(
+            (c.get("name", "") if isinstance(c, dict) else "")
+            + (c.get("joinphrase", "") if isinstance(c, dict) else "")
+            for c in credits
+        ).strip()
+        return name or None
+    except Exception as e:
+        logger.debug(f"MusicBrainz recording artist lookup failed: {e}")
     return None
 
 

--- a/metadata.py
+++ b/metadata.py
@@ -483,17 +483,78 @@ def _musicbrainz_throttle():
         _mb_last_request_time = time.monotonic()
 
 
+_MB_RETRY_ATTEMPTS = 5
+_MB_RETRY_BACKOFF = 2.0
+_MB_RETRY_STATUS = (429, 500, 502, 503, 504)
+
+
+def _musicbrainz_get(url, params, label="lookup"):
+    """GET a MusicBrainz endpoint, throttled and retried on 503/timeouts.
+
+    MusicBrainz answers with HTTP 503 ("currently busy") whenever the
+    server is loaded or our source IP has been rate-limited, so a single
+    attempt fails spuriously. Retries up to ``_MB_RETRY_ATTEMPTS`` times
+    with exponential backoff (honouring ``Retry-After`` when present) and
+    the usual 1 req/s throttle between attempts.
+
+    Returns the successful ``Response``, or None if every attempt failed.
+    """
+    for attempt in range(1, _MB_RETRY_ATTEMPTS + 1):
+        try:
+            _musicbrainz_throttle()
+            r = requests.get(
+                url, params=params, headers=_API_HEADERS, timeout=10
+            )
+            if r.status_code == 200:
+                return r
+            if r.status_code in _MB_RETRY_STATUS \
+                    and attempt < _MB_RETRY_ATTEMPTS:
+                delay = _MB_RETRY_BACKOFF ** (attempt - 1)
+                try:
+                    delay = max(delay, float(r.headers.get("Retry-After", 0)))
+                except (TypeError, ValueError):
+                    pass
+                logger.info(
+                    "      MB %s: HTTP %s, retrying in %.1fs (attempt %d/%d)",
+                    label, r.status_code, delay, attempt, _MB_RETRY_ATTEMPTS,
+                )
+                time.sleep(delay)
+                continue
+            logger.info(
+                "      MB %s failed: HTTP %s after %d attempt(s), body: %.300s",
+                label, r.status_code, attempt, r.text,
+            )
+            return None
+        except Exception as e:
+            if attempt < _MB_RETRY_ATTEMPTS:
+                delay = _MB_RETRY_BACKOFF ** (attempt - 1)
+                logger.info(
+                    "      MB %s: %s: %s, retrying in %.1fs"
+                    " (attempt %d/%d)",
+                    label, type(e).__name__, e, delay,
+                    attempt, _MB_RETRY_ATTEMPTS,
+                )
+                time.sleep(delay)
+                continue
+            logger.info(
+                "      MB %s failed after %d attempt(s): %s: %s",
+                label, attempt, type(e).__name__, e,
+            )
+    return None
+
+
 def _musicbrainz_release_id(artist, album):
     """Resolve a MusicBrainz release id (uuid) for artist+album, or None."""
     try:
-        _musicbrainz_throttle()
         url = "https://musicbrainz.org/ws/2/release/"
         params = {
             "query": f'artist:"{artist}" AND release:"{album}"',
             "fmt": "json",
             "limit": 5,
         }
-        r = requests.get(url, params=params, headers=_API_HEADERS, timeout=10)
+        r = _musicbrainz_get(url, params, label="release lookup")
+        if r is None:
+            return None
         data = r.json() or {}
         releases = data.get("releases", []) or []
         artist_lower = (artist or "").lower()
@@ -536,10 +597,11 @@ def get_musicbrainz_recording_artist(recording_id):
     if not recording_id:
         return None
     try:
-        _musicbrainz_throttle()
         url = f"https://musicbrainz.org/ws/2/recording/{recording_id}"
         params = {"fmt": "json", "inc": "artist-credits"}
-        r = requests.get(url, params=params, headers=_API_HEADERS, timeout=10)
+        r = _musicbrainz_get(url, params, label="artist lookup")
+        if r is None:
+            return None
         data = r.json() or {}
         credits = data.get("artist-credit", []) or []
         name = "".join(

--- a/models.py
+++ b/models.py
@@ -101,6 +101,7 @@ def add_track_download(
     duration_seconds, album_path, lidarr_album_path, cover_url,
     acoustid_fingerprint_id="", acoustid_score=0.0,
     acoustid_recording_id="", acoustid_recording_title="",
+    track_artist="",
 ):
     """Record a single track download attempt."""
     conn = db.get_db()
@@ -112,9 +113,9 @@ def add_track_download(
             album_path, lidarr_album_path, cover_url,
             acoustid_fingerprint_id, acoustid_score,
             acoustid_recording_id, acoustid_recording_title,
-            timestamp)
+            track_artist, timestamp)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                   ?, ?, ?, ?, ?)""",
+                   ?, ?, ?, ?, ?, ?)""",
         (
             album_id, album_title, artist_name, track_title,
             track_number, int(success), error_message, youtube_url,
@@ -122,7 +123,7 @@ def add_track_download(
             album_path, lidarr_album_path, cover_url,
             acoustid_fingerprint_id, acoustid_score,
             acoustid_recording_id, acoustid_recording_title,
-            time.time(),
+            track_artist, time.time(),
         ),
     )
     conn.commit()
@@ -204,7 +205,8 @@ def get_failed_tracks_for_retry(album_id):
     # Get the latest attempt per track
     rows = conn.execute(
         """
-        SELECT t1.track_title, t1.track_number, t1.error_message
+        SELECT t1.track_title, t1.track_number, t1.error_message,
+               t1.track_artist
         FROM track_downloads t1
         INNER JOIN (
             SELECT track_title, MAX(timestamp) as max_ts
@@ -225,6 +227,7 @@ def get_failed_tracks_for_retry(album_id):
                 "title": row["track_title"],
                 "reason": row["error_message"],
                 "track_num": row["track_number"],
+                "artist": row["track_artist"] or ctx["artist_name"],
             }
             for row in rows
         ],

--- a/processing.py
+++ b/processing.py
@@ -32,6 +32,7 @@ from metadata import (
     get_deezer_artwork,
     get_itunes_artwork,
     get_itunes_tracks,
+    get_musicbrainz_recording_artist,
 )
 from notifications import (
     build_musicbrainz_link,
@@ -312,6 +313,77 @@ def stop_download():
         models.clear_queue()
 
 
+def _match_itunes_track(itunes_tracks, track):
+    """Find the iTunes track dict matching a Lidarr/local track by number
+    or, failing that, by normalized title."""
+    track_num = track.get("trackNumber")
+    if track_num is not None:
+        for it in itunes_tracks:
+            if it.get("trackNumber") == track_num:
+                return it
+    title = (track.get("title") or "").strip().lower()
+    if title:
+        for it in itunes_tracks:
+            if (it.get("title") or "").strip().lower() == title:
+                return it
+    return None
+
+
+def _resolve_track_artists(tracks, artist_name, album_title, source):
+    """Resolve a per-track artist for each track, per ``search_artist_source``.
+
+    Lidarr's track resource has no per-track artist field, so for
+    compilation albums (Lidarr artist "Various Artists") the YouTube search
+    otherwise has no real artist to search for. Depending on ``source``,
+    resolve one via MusicBrainz and/or iTunes, in the configured order;
+    sets ``track["artist"]`` when found.
+    """
+    if source == "album" or not tracks:
+        return
+
+    use_mb = source in ("mb_itunes", "itunes_mb", "mb")
+    use_itunes = source in ("mb_itunes", "itunes_mb", "itunes")
+    mb_first = source in ("mb_itunes", "mb")
+
+    itunes_tracks = None
+
+    def _try_itunes(track):
+        nonlocal itunes_tracks
+        if itunes_tracks is None:
+            itunes_tracks = get_itunes_tracks(artist_name, album_title) or []
+        match = _match_itunes_track(itunes_tracks, track)
+        return (match or {}).get("artist")
+
+    def _try_mb(track):
+        return get_musicbrainz_recording_artist(track.get("foreignRecordingId"))
+
+    for track in tracks:
+        resolved = None
+        if mb_first:
+            if use_mb:
+                resolved = _try_mb(track)
+            if not resolved and use_itunes:
+                resolved = _try_itunes(track)
+        else:
+            if use_itunes:
+                resolved = _try_itunes(track)
+            if not resolved and use_mb:
+                resolved = _try_mb(track)
+        if resolved:
+            track["artist"] = resolved
+            logger.info(
+                "   Track artist resolved (%s): '%s' -> '%s'"
+                " (album artist: '%s')",
+                source, track.get("title", "?"), resolved, artist_name,
+            )
+        else:
+            logger.info(
+                "   Track artist not resolved (%s): '%s'"
+                " -> keeping album artist '%s'",
+                source, track.get("title", "?"), artist_name,
+            )
+
+
 def process_album_download(album_id, force=False, client_grab=False, state=None):
     """Download all tracks for an album and import into Lidarr.
 
@@ -401,6 +473,10 @@ def process_album_download(album_id, force=False, client_grab=False, state=None)
         album["tracks"] = tracks
 
         artist_name = album["artist"]["artistName"]
+        search_artist_source = load_config().get("search_artist_source", "album")
+        _resolve_track_artists(
+            tracks, artist_name, album["title"], search_artist_source,
+        )
         artist_id = album["artist"]["id"]
         artist_mbid = album["artist"].get("foreignArtistId", "")
         album_title = album["title"]
@@ -906,7 +982,7 @@ def _build_candidate_attempt(
 def _accept_track_file(
     src_file, track_num, sanitized_track, dl_result, fp_data,
     *, track_state, track_title, album_path, album_ctx,
-    candidate_attempts=None,
+    candidate_attempts=None, track_artist=None,
 ):
     """Accept a downloaded file: XML metadata, move, record in DB.
 
@@ -939,6 +1015,7 @@ def _accept_track_file(
             album_id=album_ctx["album_id"],
             album_title=album_ctx["album_title"],
             artist_name=album_ctx["artist_name"],
+            track_artist=track_artist or album_ctx["artist_name"],
             track_title=track_title,
             track_number=track_num, success=True,
             error_message="",
@@ -987,7 +1064,7 @@ def _accept_track_file(
 def _record_track_failure(
     fail_reason, track_state, track_title, track_num,
     *, album_path, album_ctx, failed_tracks, _results_lock,
-    candidate_attempts=None,
+    candidate_attempts=None, track_artist=None,
 ):
     """Record a track failure in state, failed_tracks list, and DB."""
     track_state["status"] = "failed"
@@ -1005,6 +1082,7 @@ def _record_track_failure(
             album_id=album_ctx["album_id"],
             album_title=album_ctx["album_title"],
             artist_name=album_ctx["artist_name"],
+            track_artist=track_artist or album_ctx["artist_name"],
             track_title=track_title,
             track_number=track_num, success=False,
             error_message=fail_reason,
@@ -1097,6 +1175,7 @@ def _download_tracks(
             track_num = idx + 1
         track_duration_ms = track.get("duration")
         expected_recording_id = track.get("foreignRecordingId")
+        track_artist = track.get("artist") or artist_name
         sanitized_track = sanitize_filename(track_title)
 
         def _skip_check():
@@ -1161,8 +1240,14 @@ def _download_tracks(
                     "   No album-playlist match for '%s';"
                     " falling back to per-track search", track_title,
                 )
+            base_query = f"{track_artist} {track_title} official audio"
+            logger.info(
+                "   Per-track search query for '%s': \"%s\""
+                " (track_artist='%s')",
+                track_title, base_query, track_artist,
+            )
             candidates = search_youtube_candidates(
-                f"{artist_name} {track_title} official audio",
+                base_query,
                 track_title, track_duration_ms,
                 skip_check=_skip_check, banned_urls=banned_url_set,
             )
@@ -1178,6 +1263,7 @@ def _download_tracks(
                 album_path=album_path, album_ctx=album_ctx,
                 failed_tracks=failed_tracks,
                 _results_lock=_results_lock,
+                track_artist=track_artist,
             )
             return
 
@@ -1450,6 +1536,7 @@ def _download_tracks(
                 album_path=album_path,
                 album_ctx=album_ctx,
                 candidate_attempts=candidate_attempts_buf,
+                track_artist=track_artist,
             )
             with _results_lock:
                 total_downloaded_size += file_size
@@ -1545,6 +1632,7 @@ def _download_tracks(
                         candidate_attempts=(
                             candidate_attempts_buf
                         ),
+                        track_artist=track_artist,
                     )
                     with _results_lock:
                         total_downloaded_size += file_size
@@ -1614,6 +1702,7 @@ def _download_tracks(
                 failed_tracks=failed_tracks,
                 _results_lock=_results_lock,
                 candidate_attempts=candidate_attempts_buf,
+                track_artist=track_artist,
             )
 
     with ThreadPoolExecutor(max_workers=concurrent_tracks) as executor:

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -1398,7 +1398,8 @@
                 searchInput.id = 'retrySearch' + i;
                 searchInput.placeholder = 'Search YouTube…';
                 searchInput.value = (
-                    (data.artist_name || '') + ' ' + (track.title || '')
+                    (track.artist || data.artist_name || '') + ' '
+                    + (track.title || '')
                 ).trim();
                 searchInput.style.cssText = 'flex:1 1 auto; min-width:0;';
                 searchInput.addEventListener('keydown', (e) => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -3932,7 +3932,7 @@
                     </div>
                     <div class="failed-track-inputs" id="failedSearchRow${i}">
                         <input type="text" id="failedSearch${i}" placeholder="Search YouTube..."
-                            value="${escapeHtml((data.artist_name || "") + " " + track.title)}"
+                            value="${escapeHtml((track.artist || data.artist_name || "") + " " + track.title)}"
                             onkeydown="if(event.key==='Enter')searchFailedTrack(${i})">
                         <button class="ft-btn" onclick="searchFailedTrack(${i})">
                             <i class="fa-solid fa-search"></i> Search

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -825,6 +825,19 @@
                 </select>
             </div>
             <div class="input-group">
+                <label for="searchArtistSource">
+                    YouTube Search Artist
+                    <div class="label-description">Which artist to use when building the YouTube search query for a track. "Lidarr Album Artist" is instant but shows "Various Artists" for compilations, so those tracks often can't be found. The other options resolve the real per-track artist via MusicBrainz and/or iTunes before falling back to the album artist — more accurate, but adds up to ~1s per track (MusicBrainz rate limit) to the search step.</div>
+                </label>
+                <select id="searchArtistSource" style="max-width:340px;">
+                    <option value="album">Lidarr Album Artist (default, fastest)</option>
+                    <option value="mb_itunes">Track Artist (MusicBrainz, iTunes fallback)</option>
+                    <option value="itunes_mb">Track Artist (iTunes, MusicBrainz fallback)</option>
+                    <option value="mb">Track Artist (MusicBrainz only)</option>
+                    <option value="itunes">Track Artist (iTunes only)</option>
+                </select>
+            </div>
+            <div class="input-group">
                 <label for="audioFormatSelect">
                     Audio Format
                     <div class="label-description">M4A and Opus prefer the native YouTube stream and stream-copy without re-encoding (no quality loss). MP3 always transcodes.</div>
@@ -1391,6 +1404,7 @@ SABnzbd client   → URL Base:  /api/sabnzbd/</pre>
             document.getElementById('durationTolerance').value = conf.duration_tolerance || 10;
             document.getElementById('minMatchScore').value = conf.min_match_score != null ? conf.min_match_score : 0.8;
             document.getElementById('concurrentTracks').value = conf.concurrent_tracks || 2;
+            document.getElementById('searchArtistSource').value = conf.search_artist_source || 'album';
             document.getElementById('audioFormatSelect').value = conf.audio_format || 'mp3';
             document.getElementById('audioQualitySelect').value = String(conf.audio_quality || '320');
             document.getElementById('ytdlpFormat').value = conf.ytdlp_format || '';
@@ -1908,6 +1922,7 @@ SABnzbd client   → URL Base:  /api/sabnzbd/</pre>
                     duration_tolerance: parseInt(document.getElementById('durationTolerance').value) || 10,
                     min_match_score: parseFloat(document.getElementById('minMatchScore').value) || 0.8,
                     concurrent_tracks: parseInt(document.getElementById('concurrentTracks').value) || 2,
+                    search_artist_source: document.getElementById('searchArtistSource').value || 'album',
                     audio_format: document.getElementById('audioFormatSelect').value || 'mp3',
                     audio_quality: document.getElementById('audioQualitySelect').value || '320',
                     ytdlp_format: (document.getElementById('ytdlpFormat').value || '').trim(),

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -221,12 +221,86 @@ class TestGetDeezerArtwork:
         assert metadata.get_deezer_artwork("X", "Y") is None
 
 
+@patch("metadata.time.sleep", lambda *_: None)
+class TestGetMusicbrainzRecordingArtist:
+    def _ok(self, credits):
+        return MagicMock(
+            status_code=200, json=lambda: {"artist-credit": credits}
+        )
+
+    def test_returns_none_without_recording_id(self):
+        assert metadata.get_musicbrainz_recording_artist(None) is None
+        assert metadata.get_musicbrainz_recording_artist("") is None
+
+    @patch("metadata.requests.get")
+    def test_joins_artist_credit_phrase(self, mock_get):
+        mock_get.return_value = self._ok([
+            {"name": "Artist A", "joinphrase": " feat. "},
+            {"name": "Artist B", "joinphrase": ""},
+        ])
+        result = metadata.get_musicbrainz_recording_artist("rec-1")
+        assert result == "Artist A feat. Artist B"
+
+    @patch("metadata.requests.get")
+    def test_retries_on_503_and_succeeds(self, mock_get):
+        mock_get.side_effect = [
+            MagicMock(status_code=503, text="busy", headers={}),
+            MagicMock(status_code=503, text="busy", headers={}),
+            self._ok([{"name": "Zaho", "joinphrase": ""}]),
+        ]
+        result = metadata.get_musicbrainz_recording_artist("rec-1")
+        assert result == "Zaho"
+        assert mock_get.call_count == 3
+
+    @patch("metadata.requests.get")
+    def test_gives_up_after_configured_attempts(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=503, text="busy", headers={}
+        )
+        assert metadata.get_musicbrainz_recording_artist("rec-1") is None
+        assert mock_get.call_count == metadata._MB_RETRY_ATTEMPTS
+
+    @patch("metadata.requests.get")
+    def test_retries_on_network_error(self, mock_get):
+        mock_get.side_effect = [
+            Exception("timeout"),
+            self._ok([{"name": "Zaho", "joinphrase": ""}]),
+        ]
+        assert metadata.get_musicbrainz_recording_artist("rec-1") == "Zaho"
+        assert mock_get.call_count == 2
+
+    @patch("metadata.requests.get")
+    def test_does_not_retry_on_404(self, mock_get):
+        mock_get.return_value = MagicMock(
+            status_code=404, text="not found", headers={}
+        )
+        assert metadata.get_musicbrainz_recording_artist("rec-1") is None
+        assert mock_get.call_count == 1
+
+    @patch("metadata.requests.get")
+    def test_honours_retry_after_header(self, mock_get):
+        mock_get.side_effect = [
+            MagicMock(status_code=503, text="busy", headers={
+                "Retry-After": "5",
+            }),
+            self._ok([{"name": "Zaho", "joinphrase": ""}]),
+        ]
+        with patch("metadata.time.sleep") as mock_sleep:
+            assert metadata.get_musicbrainz_recording_artist("rec-1") == "Zaho"
+        assert 5.0 in [c[0][0] for c in mock_sleep.call_args_list]
+
+    @patch("metadata.requests.get")
+    def test_returns_none_on_empty_credit(self, mock_get):
+        mock_get.return_value = self._ok([])
+        assert metadata.get_musicbrainz_recording_artist("rec-1") is None
+
+
 class TestGetCoverArtArchiveArtwork:
     @patch("metadata.requests.get")
     def test_returns_artwork_via_musicbrainz_release(self, mock_get):
         # MusicBrainz returns a release id, then CAA returns image bytes.
         mock_get.side_effect = [
-            MagicMock(json=lambda: {
+            MagicMock(status_code=200, json=lambda: {
                 "releases": [
                     {
                         "id": "abc-uuid",
@@ -244,7 +318,9 @@ class TestGetCoverArtArchiveArtwork:
 
     @patch("metadata.requests.get")
     def test_returns_none_when_musicbrainz_has_no_release(self, mock_get):
-        mock_get.return_value = MagicMock(json=lambda: {"releases": []})
+        mock_get.return_value = MagicMock(
+            status_code=200, json=lambda: {"releases": []}
+        )
         result = metadata.get_cover_art_archive_artwork("X", "Y")
         assert result is None
         assert mock_get.call_count == 1
@@ -252,7 +328,7 @@ class TestGetCoverArtArchiveArtwork:
     @patch("metadata.requests.get")
     def test_returns_none_on_caa_404(self, mock_get):
         mock_get.side_effect = [
-            MagicMock(json=lambda: {
+            MagicMock(status_code=200, json=lambda: {
                 "releases": [
                     {
                         "id": "abc",

--- a/version.py
+++ b/version.py
@@ -1,0 +1,6 @@
+"""Single source of truth for the application version."""
+
+VERSION = "1.8.5"
+
+# User-Agent sent to third-party APIs
+USER_AGENT = f"Lidarr-YouTube-Downloader/{VERSION}"


### PR DESCRIPTION
Resolve #86 by looking up each track's actual artist via MusicBrainz and/or iTunes and searching YouTube for `<track artist> - <title>` instead of the album artist.

Lidarr itself has no per-track artist field, so the lookup is opt-in via the new search_artist_source setting and falls back to the album artist when nothing is found. The resolved artist is stored per track, so retries of failed compilation tracks also search correctly.

**New Setting:**
<img width="857" height="339" alt="grafik" src="https://github.com/user-attachments/assets/5365bae2-d172-43bb-94de-51f0e4fd859c" />

**Before/After:**
<img width="2560" height="1293" alt="Screenshot 2026-08-22 at 14-42-36 Lidarr YouTube Downloader" src="https://github.com/user-attachments/assets/2bcaeecd-5f78-48f6-a2f9-1cb5913d0344" />
<img width="2560" height="1293" alt="Screenshot 2026-08-22 at 14-43-55 Lidarr YouTube Downloader" src="https://github.com/user-attachments/assets/9e58fdbe-3fca-4fe4-ab08-8aebdf71ce41" />

