### PR TITLE
Release 1.8.6: per-track artist search for compilations (#86/#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.8.6
+
+### Added
+- **Per-track artist for compilations** (Settings → "Search Artist Source",
+  env `SEARCH_ARTIST_SOURCE`, default `album`): on compilation albums Lidarr
+  sets the album artist to "Various Artists", so the old YouTube search
+  (`Various Artists - <title>`) matched nothing. The app can now resolve
+  each track's real artist via MusicBrainz and/or iTunes and search for
+  `<track artist> - <title>` instead, falling back to the album artist when
+  it can't be resolved. Default keeps the previous album-artist behavior.
+  (#86 — thanks @aki-ks)
+
+### Fixed
+- **Third-party API requests now send a proper `User-Agent`** — MusicBrainz,
+  AcoustID and the Cover Art Archive require an identifying User-Agent;
+  requests now carry the real app version, avoiding throttling/rejection.
+  MusicBrainz lookups are throttled to 1 req/s and retried with backoff on
+  `503`/`Retry-After`. (thanks @aki-ks)
+
 ## 1.8.5
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ Standalone scripts not part of the main app:
 
 ## Version Updates
 
-The version string is defined in `version.py`: `VERSION = "1.8.5"`. The README badge also references it and must be updated manually.
+The version string is defined in `version.py`: `VERSION = "1.8.6"`. The README badge also references it and must be updated manually.
 
 ## Persistence Volume
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🎵 Lidarr YouTube Downloader
 
-![Version](https://img.shields.io/badge/version-1.8.5-blue.svg?style=for-the-badge)
+![Version](https://img.shields.io/badge/version-1.8.6-blue.svg?style=for-the-badge)
 ![Python Slim](https://img.shields.io/badge/python-3--slim-yellow.svg?style=for-the-badge&logo=python&logoColor=white)
 ![Docker](https://img.shields.io/badge/docker-ready-blue.svg?style=for-the-badge&logo=docker&logoColor=white)
 ![License](https://img.shields.io/badge/license-MIT-green.svg?style=for-the-badge)

--- a/version.py
+++ b/version.py
@@ -1,6 +1,6 @@
 """Single source of truth for the application version."""
 
-VERSION = "1.8.5"
+VERSION = "1.8.6"
 
 # User-Agent sent to third-party APIs
 USER_AGENT = f"Lidarr-YouTube-Downloader/{VERSION}"


### PR DESCRIPTION
Bump VERSION (version.py), README badge and CLAUDE.md to 1.8.6, and add a 1.8.6 changelog covering the work merged in PR #87: per-track artist resolution for "Various Artists" compilations (config search_artist_source, default album keeps prior behavior) and the proper User-Agent on the MusicBrainz/AcoustID/Cover Art Archive API calls with 1 req/s throttling and 503 retry.

https://claude.ai/code/session_019GZ9hj34nVbtFWv5Wrebvf